### PR TITLE
Add support for null objects

### DIFF
--- a/jsxon.amd.js
+++ b/jsxon.amd.js
@@ -3,6 +3,9 @@ define(['react'], function(React){
   var specialProperties = ['el', 'children', 'text', 'defaultEl'];
 
   var jsxon = function(obj, defaultEl){
+    if(!obj){
+      return undefined;
+    }
 
     if(obj.className && obj.className.join){
       obj.className = obj.className.join(' ');

--- a/jsxon.cjs.js
+++ b/jsxon.cjs.js
@@ -3,6 +3,9 @@ var React = require('react');
 var specialProperties = ['el', 'children', 'text', 'defaultEl'];
 
 var jsxon = function(obj, defaultEl){
+  if(!obj){
+    return undefined;
+  }
 
   if(obj.className && obj.className.join){
     obj.className = obj.className.join(' ');

--- a/specs/jsxon.amd.spec.js
+++ b/specs/jsxon.amd.spec.js
@@ -159,4 +159,16 @@ describe('jsxon', function(){
 
   });
 
+  context('when the object is undefined', function(){
+
+    beforeEach(function(){
+      result = jsxon(undefined);
+    });
+
+    it('returns undefined', function(){
+      expect(result).to.eql(undefined);
+    });
+
+  });
+
 });


### PR DESCRIPTION
Allows you to pass a null object into jsxon, so that you can write things like:

```
{
  children: [
    renderSomething()
  ]
}

function renderSomething(){
  if(false){
    return {
      el: 'div'
    }
  }
}
```
